### PR TITLE
Specify a non-sliding timeout in the example

### DIFF
--- a/sample/Example/NLog.config
+++ b/sample/Example/NLog.config
@@ -10,7 +10,8 @@
     <target name="seq"
             xsi:type="BufferingWrapper"            
             bufferSize="1000"
-            flushTimeout="2000">
+            flushTimeout="2000"
+            slidingTimeout="false">
 
       <target xsi:type="Seq" serverUrl="http://localhost:5341" apiKey="">
         <property name="ThreadId" value="${threadid}" as="number" />


### PR DESCRIPTION
Hi there!

The NLog behaviour with a buffer size of 1000 events and flush timeout of 2000ms as in the example is to flush if
1) The buffer hits 1000 events
OR
2) Nothing is written for 2000ms, triggering a flush.

I spent some time trying to work out why my test of log-then-sleep-for-500ms in a loop wasn't writing to seq, and it's because the logger has a sliding window by default! So as my loop kept writing, it wouldn't flush till it reached 1000 events.

I suspect the sample uses 1000/2000 as the buffer/timeout values so that writes to seq are nicely batched, though perhaps turning off the sliding window might make it clearer what's going on?

Hope this might help others who are new to NLog like I am!