### PR TITLE
SeqPropertyItem - Added AsString that matches NLog.Layouts.JsonAttribute.Encode

### DIFF
--- a/src/NLog.Targets.Seq/SeqPropertyItem.cs
+++ b/src/NLog.Targets.Seq/SeqPropertyItem.cs
@@ -24,14 +24,6 @@ namespace NLog.Targets.Seq
     public sealed class SeqPropertyItem
     {
         /// <summary>
-        /// Initialize parameter defaults.
-        /// </summary>
-        public SeqPropertyItem()        
-        {
-            As = "string";
-        }
-
-        /// <summary>
         /// The name of the property.
         /// </summary>
         [RequiredParameter]
@@ -44,13 +36,22 @@ namespace NLog.Targets.Seq
         public Layout Value { get; set; }
 
         /// <summary>
+        /// Gets or sets whether value should be handled as string-value.
+        /// </summary>
+        /// <remarks>
+        /// Matches <see cref="NLog.Layouts.JsonAttribute.Encode"/>
+        /// </remarks>
+        public bool AsString { get; set; } = true;
+
+        /// <summary>
         /// Either "string", which is the default, or "number", which
         /// will cause values of this type to be converted to numbers for
         /// storage.
         /// </summary>
-        [RequiredParameter]
-        public string As { get; set; }
-
-        internal bool IsNumber => As == "number";
+        public string As
+        {
+            get => AsString ? "string" : "number";
+            set => AsString = value != "number";
+        }
     }
 }

--- a/src/NLog.Targets.Seq/SeqTarget.cs
+++ b/src/NLog.Targets.Seq/SeqTarget.cs
@@ -116,7 +116,7 @@ namespace NLog.Targets.Seq
         {
             foreach (var prop in Properties)
             {
-                var attr = new JsonAttribute(prop.Name, prop.Value, !prop.IsNumber);
+                var attr = new JsonAttribute(prop.Name, prop.Value, prop.AsString);
                 TextClefLayout.Attributes.Add(attr);
                 TemplatedClefLayout.Attributes.Add(attr);
             }


### PR DESCRIPTION
Think this makes more sense:
```xml
<property name="scopenested" value="${scopenested:format=@}" asString="false" />
```

Than this:

```xml
<property name="scopenested" value="${scopenested:format=@}" as="number" />
```

Maybe consider the property-name "ValueToString" instead of "AsString".