### PR TITLE
LogEvent without message template parameters should output formatted message

### DIFF
--- a/nlog-targets-seq.sln
+++ b/nlog-targets-seq.sln
@@ -1,19 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29209.62
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33627.172
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{AC295EEA-D319-4146-97E0-B978DF6F2557}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "global", "global", "{66B005E9-A083-41E8-BD89-4D6E753CD8BF}"
 	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml
 		Build.ps1 = Build.ps1
 		LICENSE = LICENSE
 		README.md = README.md
-		.gitattributes = .gitattributes
-		.gitignore = .gitignore
-		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{2ED926D3-7AC8-4BFD-A16B-74D942602968}"

--- a/src/NLog.Targets.Seq/CompactJsonLayout.cs
+++ b/src/NLog.Targets.Seq/CompactJsonLayout.cs
@@ -13,36 +13,30 @@
 // limitations under the License.
 
 using System;
+using NLog.Config;
 using NLog.Layouts;
 
 namespace NLog.Targets.Seq
 {
+    [ThreadAgnostic]
     class CompactJsonLayout : JsonLayout
     {
         readonly JsonAttribute
-            _timestampAttribute = new JsonAttribute("@t", new SimpleLayout("${date:o}")),
+            _timestampAttribute = new JsonAttribute("@t", new SimpleLayout("${date:format=o}")),
             _levelAttribute = new JsonAttribute("@l", new SimpleLayout("${level}")),
             _exceptionAttribute = new JsonAttribute("@x", new SimpleLayout("${exception:format=toString}")),
-            _messageAttribute = new JsonAttribute("@m", new SimpleLayout("${message}")),
-            _messageTemplateAttribute = new JsonAttribute("@mt", new SimpleLayout("${message:raw=true}"));
+            _messageAttribute = new JsonAttribute("@m", new FormattedMessageLayout()),
+            _messageTemplateAttribute = new JsonAttribute("@mt", new SimpleLayout("${onhasproperties:${message:raw=true}}"));
 
-        public CompactJsonLayout(bool usesTemplate)
+        public CompactJsonLayout()
         {
             Attributes.Add(_timestampAttribute);
             Attributes.Add(_levelAttribute);
             Attributes.Add(_exceptionAttribute);
-            
-            if (usesTemplate)
-            {
-                Attributes.Add(_messageTemplateAttribute);
-                
-                var renderingsAttribute = new JsonAttribute("@r", new RenderingsLayout(new Lazy<IJsonConverter>(ResolveService<IJsonConverter>)), encode: false);
-                Attributes.Add(renderingsAttribute);
-            }
-            else
-            {
-                Attributes.Add(_messageAttribute);
-            }
+            Attributes.Add(_messageTemplateAttribute);
+            var renderingsAttribute = new JsonAttribute("@r", new RenderingsLayout(new Lazy<IJsonConverter>(ResolveService<IJsonConverter>)), encode: false);
+            Attributes.Add(renderingsAttribute);
+            Attributes.Add(_messageAttribute);
 
             IncludeEventProperties = true;
             IncludeScopeProperties = true;

--- a/src/NLog.Targets.Seq/FormattedMessageLayout.cs
+++ b/src/NLog.Targets.Seq/FormattedMessageLayout.cs
@@ -1,0 +1,53 @@
+﻿// Seq Target for NLog - Copyright 2014-2017 Datalust and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+using NLog.Config;
+using NLog.Layouts;
+
+namespace NLog.Targets.Seq
+{
+    [ThreadAgnostic]
+    class FormattedMessageLayout : Layout
+    {
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        {
+            target.Append(GetFormattedMessage(logEvent));
+        }
+
+        protected override string GetFormattedMessage(LogEventInfo logEvent)
+        {
+            if (HasMessageTemplateSyntax(logEvent))
+            {
+                return string.Empty;    // Message Template Syntax, no need to include formatted message
+            }
+
+            return logEvent.FormattedMessage;
+        }
+
+        bool HasMessageTemplateSyntax(LogEventInfo logEvent)
+        {
+            if (!logEvent.HasProperties)
+                return false;
+
+            if (logEvent.Message?.IndexOf("{0", System.StringComparison.Ordinal) >= 0)
+            {
+                var mtp = logEvent.MessageTemplateParameters;
+                return !mtp.IsPositional;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/NLog.Targets.Seq/SeqTarget.cs
+++ b/src/NLog.Targets.Seq/SeqTarget.cs
@@ -35,6 +35,8 @@ namespace NLog.Targets.Seq
         Layout _serverUrl;
         Layout _apiKey;
         Layout _proxyAddress;
+        readonly JsonLayout _compactLayout = new CompactJsonLayout();
+        readonly char[] _reusableEncodingBuffer = new char[32 * 1024];  // Avoid large-object-heap
 
         Uri _webRequestUri;
         string _headerApiKey;
@@ -46,12 +48,12 @@ namespace NLog.Targets.Seq
         /// <summary>
         /// The layout used to format `LogEvent`s as compact JSON.
         /// </summary>
-        public JsonLayout TemplatedClefLayout { get; } = new CompactJsonLayout(true);
+        public JsonLayout TemplatedClefLayout => _compactLayout;
 
         /// <summary>
         /// The layout used to format `LogEvent`s as compact JSON.
         /// </summary>
-        public JsonLayout TextClefLayout { get; } = new CompactJsonLayout(false);
+        public JsonLayout TextClefLayout => _compactLayout;
 
         /// <summary>
         /// Maximum size allowed for JSON payload sent to Seq-Server. Discards log events that are larger than limit.
@@ -93,8 +95,17 @@ namespace NLog.Targets.Seq
         /// </summary>
         public int MaxRecursionLimit
         {
-            get => TemplatedClefLayout.MaxRecursionLimit;
-            set { TemplatedClefLayout.MaxRecursionLimit = value; TextClefLayout.MaxRecursionLimit = value; }
+            get => _compactLayout.MaxRecursionLimit;
+            set => _compactLayout.MaxRecursionLimit = value;
+        }
+
+        /// <summary>
+        /// Gets or sets whether to include the contents of the <see cref="ScopeContext"/> dictionary.
+        /// </summary>
+        public bool IncludeScopeProperties
+        {
+            get => _compactLayout.IncludeScopeProperties;
+            set => _compactLayout.IncludeScopeProperties = value;
         }
 
         /// <summary>
@@ -116,8 +127,7 @@ namespace NLog.Targets.Seq
             foreach (var prop in Properties)
             {
                 var attr = new JsonAttribute(prop.Name, prop.Value, prop.AsString);
-                TextClefLayout.Attributes.Add(attr);
-                TemplatedClefLayout.Attributes.Add(attr);
+                AddJsonAttribute(_compactLayout, attr);
             }
 
             if (!string.IsNullOrEmpty(ServerUrl))
@@ -199,12 +209,7 @@ namespace NLog.Targets.Seq
             if (_webRequestUri == null)
                 return;
 
-            var request = new HttpRequestMessage(HttpMethod.Post, _webRequestUri);
-            if (!string.IsNullOrWhiteSpace(_headerApiKey))
-                request.Headers.Add(SeqApi.ApiKeyHeaderName, _headerApiKey);
-
             List<AsyncLogEventInfo> extraBatch = null;
-            var totalPayload = 0;
             var payload = new StringBuilder();
 
             for (var i = 0; i < logEvents.Count; ++i)
@@ -214,29 +219,52 @@ namespace NLog.Targets.Seq
                 if (evt.Level < _minimumLevel)
                     continue;
 
-                var json = RenderCompactJsonLine(evt);
-
-                if (JsonPayloadMaxLength > 0)
+                int orgLength = payload.Length;
+                var jsonLength = RenderCompactJsonLine(evt, payload);
+                if (jsonLength > JsonPayloadMaxLength)
                 {
-                    if (json.Length > JsonPayloadMaxLength)
-                    {
-                        InternalLogger.Warn("Seq(Name={0}): Event JSON representation exceeds the char limit: {1} > {2}", Name, json.Length, JsonPayloadMaxLength);
-                        continue;
-                    }
-                    if (totalPayload + json.Length > JsonPayloadMaxLength)
-                    {
-                        extraBatch = new List<AsyncLogEventInfo>(logEvents.Count - i);
-                        for (; i < logEvents.Count; ++i)
-                            extraBatch.Add(logEvents[i]);
-                        break;
-                    }
+                    InternalLogger.Warn("Seq(Name={0}): Event JSON representation exceeds the char limit: {1} > {2}", Name, jsonLength, JsonPayloadMaxLength);
+                    payload.Length = orgLength;
+                    logEvents[i].Continuation(new ArgumentException("Seq JSON Payload max length exceeded"));
                 }
-
-                totalPayload += json.Length;
-                payload.AppendLine(json);
+                else if (payload.Length > JsonPayloadMaxLength)
+                {
+                    extraBatch = new List<AsyncLogEventInfo>(logEvents.Count - i);
+                    for (; i < logEvents.Count; ++i)
+                        extraBatch.Add(logEvents[i]);
+                    payload.Length = orgLength;
+                    break;
+                }
+                else if (jsonLength > 0)
+                {
+                    payload.AppendLine();
+                }
             }
 
-            request.Content = new StringContent(payload.ToString(), Utf8, SeqApi.CompactLogEventFormatMediaType);
+            if (payload.Length > 0)
+            {
+                await SendPayload(payload).ConfigureAwait(false);
+            }
+
+            var completedCount = logEvents.Count - (extraBatch?.Count ?? 0);
+            for (var i = 0; i < completedCount; ++i)
+                logEvents[i].Continuation(null);
+
+            if (extraBatch != null)
+            {
+                await PostBatch(extraBatch).ConfigureAwait(false);
+            }
+        }
+
+        private async Task SendPayload(StringBuilder payload)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, _webRequestUri);
+            if (!string.IsNullOrWhiteSpace(_headerApiKey))
+                request.Headers.Add(SeqApi.ApiKeyHeaderName, _headerApiKey);
+
+            var httpContent = new ByteArrayContent(EncodePayload(Utf8, payload));
+            httpContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(SeqApi.CompactLogEventFormatMediaType) { CharSet = Utf8.WebName };
+            request.Content = httpContent;
 
             // Even if no events are above `_minimumLevel`, we'll send a batch to make sure we observe minimum
             // level changes sent by the server.
@@ -260,27 +288,49 @@ namespace NLog.Targets.Seq
                     }
                 }
             }
+        }
 
-            var completedCount = logEvents.Count - (extraBatch?.Count ?? 0);
-            for (var i = 0; i < completedCount; ++i)
-                logEvents[i].Continuation(null);
-
-            if (extraBatch != null)
+        private byte[] EncodePayload(Encoding encoder, StringBuilder payload)
+        {
+            lock (_reusableEncodingBuffer)
             {
-                await PostBatch(extraBatch).ConfigureAwait(false);
+                int totalLength = payload.Length;
+                if (totalLength < _reusableEncodingBuffer.Length)
+                {
+                    payload.CopyTo(0, _reusableEncodingBuffer, 0, payload.Length);
+                    return encoder.GetBytes(_reusableEncodingBuffer, 0, totalLength);
+                }
+                else
+                {
+                    return encoder.GetBytes(payload.ToString());
+                }
             }
         }
 
-        internal string RenderCompactJsonLine(LogEventInfo evt)
+        internal int RenderCompactJsonLine(LogEventInfo evt, StringBuilder payload)
         {
-            var hasProperties = evt.HasProperties && evt.Properties.Count > 0;
-            var json = RenderLogEvent(hasProperties ? TemplatedClefLayout : TextClefLayout, evt);
-            return json;
+            var orgLength = payload.Length;
+            _compactLayout.Render(evt, payload);
+            var jsonLength = payload.Length - orgLength;
+            return jsonLength;
         }
 
         internal void TestInitialize()
         {
             InitializeTarget();
+        }
+
+        private static void AddJsonAttribute(JsonLayout jsonLayout, JsonAttribute jsonAttribute)
+        {
+            for (int i = jsonLayout.Attributes.Count - 1; i >= 0; --i)
+            {
+                if (jsonLayout.Attributes[i].Name == jsonAttribute.Name)
+                {
+                    jsonLayout.Attributes.RemoveAt(i);
+                }
+            }
+
+            jsonLayout.Attributes.Add(jsonAttribute);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
In this situation then it should include `@m`:
```c#
           logger.WithProperty("EventId", 42).Info("{0}", 42);
```
Just because a LogEvent has properties, then it doesn't mean they come from message-template-syntax.

Also made some other changes:
- Merged `TemplatedClefLayout` and `TextClefLayout` together. Only perform single context-capture, instead of double-capture. NLog JsonLayout will automatically skip JsonAttribute-output when empty value.
- Render directly into `StringBuilder`-payload to avoid string-allocation for every logevent.
- Changed from `StringContent` to `ByteArrayContent` to skip string-allocation for every payload.

One might consider marking `TemplatedClefLayout` and `TextClefLayout`  as obsolete, and introduce a common `ClefLayout`-property.