### PR TITLE
Updated dependency to NLog v5.2.5 and removed NET5

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.408"
+    "version": "6.0.100",
+    "rollForward": "latestMinor"
   }
 }

--- a/nlog-targets-seq.sln
+++ b/nlog-targets-seq.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "global", "global", "{66B005
 		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml
 		Build.ps1 = Build.ps1
+		global.json = global.json
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection

--- a/src/NLog.Targets.Seq/NLog.Targets.Seq.csproj
+++ b/src/NLog.Targets.Seq/NLog.Targets.Seq.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>An NLog target that writes structured log events to Seq</Description>
     <Authors>Datalust;Contributors</Authors>
     <VersionPrefix>3.1.0</VersionPrefix>
-    <TargetFrameworks>net45;net462;netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net45;net462;netstandard2.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../asset/nlog-targets-seq.snk</AssemblyOriginatorKeyFile>
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog" Version="5.1.4" />
+    <PackageReference Include="NLog" Version="5.2.5" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net462' ">

--- a/test/NLog.Targets.Seq.Tests/NLog.Targets.Seq.Tests.csproj
+++ b/test/NLog.Targets.Seq.Tests/NLog.Targets.Seq.Tests.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/test/NLog.Targets.Seq.Tests/SeqTargetTests.cs
+++ b/test/NLog.Targets.Seq.Tests/SeqTargetTests.cs
@@ -32,9 +32,10 @@ namespace NLog.Targets.Seq.Tests
         JObject AssertValidJson(Action<ILogger> act, IEnumerable<SeqPropertyItem> properties = null, int? maxRecursionLimit = null)
         {
             var logger = LogManager.GetCurrentClassLogger();
+            var config = new LoggingConfiguration();
             var target = new CollectingTarget();
-
-            SimpleConfigurator.ConfigureForTargetLogging(target, LogLevel.Trace);
+            config.AddRuleForAllLevels(target);
+            LogManager.Configuration = config;
 
             act(logger);
 


### PR DESCRIPTION
Removed NET5 since now obsolete. And fixed obsolete warnings from NLog in unit-test-code.

NLog v5.2.5 includes several optimizations inspired by how the Seq-Target uses NLog JsonLayout.