### PR TITLE
4.0.0 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NLog.Targets.Seq [![NuGet Pre Release](https://img.shields.io/nuget/vpre/NLog.Targets.Seq.svg)](https://nuget.org/packages/NLog.Targets.Seq) [![Build status](https://ci.appveyor.com/api/projects/status/o22e6dq0mkftaggc?svg=true)](https://ci.appveyor.com/project/datalust/nlog-targets-seq)  [![Join the chat at https://gitter.im/datalust/seq](https://img.shields.io/gitter/room/datalust/seq.svg)](https://gitter.im/datalust/seq)
+# NLog.Targets.Seq [![NuGet Pre Release](https://img.shields.io/nuget/vpre/NLog.Targets.Seq.svg)](https://nuget.org/packages/NLog.Targets.Seq) [![Build status](https://ci.appveyor.com/api/projects/status/o22e6dq0mkftaggc?svg=true)](https://ci.appveyor.com/project/datalust/nlog-targets-seq)
 
 An NLog target that writes events to [Seq](https://datalust.co/seq). The target takes full advantage of the structured logging support in **NLog 4.5** to provide hassle-free filtering, searching and analysis.
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "8.0.100",
     "rollForward": "latestMinor"
   }
 }

--- a/sample/Example/Example.csproj
+++ b/sample/Example/Example.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Example</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -9,6 +9,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <ProjectReference Include="..\..\src\NLog.Targets.Seq\NLog.Targets.Seq.csproj" />
   </ItemGroup>
 

--- a/sample/Example/NLog.config
+++ b/sample/Example/NLog.config
@@ -8,7 +8,7 @@
   
   <targets>    
     <target name="seq"
-            xsi:type="BufferingWrapper"            
+            xsi:type="BufferingWrapper"
             bufferSize="1000"
             flushTimeout="2000"
             slidingTimeout="false">

--- a/sample/Example/Program.cs
+++ b/sample/Example/Program.cs
@@ -25,8 +25,6 @@ namespace Example
 
             // As are objects
             Logger.Info(new object());
-
-            Console.ReadKey();
         }
     }
 }

--- a/src/NLog.Targets.Seq/Layouts/CompactJsonLayout.cs
+++ b/src/NLog.Targets.Seq/Layouts/CompactJsonLayout.cs
@@ -16,17 +16,19 @@ using System;
 using NLog.Config;
 using NLog.Layouts;
 
-namespace NLog.Targets.Seq
+namespace NLog.Targets.Seq.Layouts
 {
     [ThreadAgnostic]
     class CompactJsonLayout : JsonLayout
     {
         readonly JsonAttribute
-            _timestampAttribute = new JsonAttribute("@t", new SimpleLayout("${date:format=o}")),
-            _levelAttribute = new JsonAttribute("@l", new SimpleLayout("${level}")),
-            _exceptionAttribute = new JsonAttribute("@x", new SimpleLayout("${exception:format=toString}")),
-            _messageAttribute = new JsonAttribute("@m", new FormattedMessageLayout()),
-            _messageTemplateAttribute = new JsonAttribute("@mt", new SimpleLayout("${onhasproperties:${message:raw=true}}"));
+            _timestampAttribute = new("@t", new SimpleLayout("${date:format=o}")),
+            _levelAttribute = new("@l", new SimpleLayout("${level}")),
+            _exceptionAttribute = new("@x", new SimpleLayout("${exception:format=toString}")),
+            _messageAttribute = new("@m", new FormattedMessageLayout()),
+            _messageTemplateAttribute = new("@mt", new SimpleLayout("${onhasproperties:${message:raw=true}}")),
+            _traceIdAttribute = new("@tr", new CurrentW3CActivityLayout(a => a.TraceId.ToHexString())),
+            _spanIdAttribute = new("@sp", new CurrentW3CActivityLayout(a => a.SpanId.ToHexString()));
 
         public Layout LogLevel { get => _levelAttribute.Layout; set => _levelAttribute.Layout = value; }
 
@@ -39,7 +41,9 @@ namespace NLog.Targets.Seq
             var renderingsAttribute = new JsonAttribute("@r", new RenderingsLayout(new Lazy<IJsonConverter>(ResolveService<IJsonConverter>)), encode: false);
             Attributes.Add(renderingsAttribute);
             Attributes.Add(_messageAttribute);
-
+            Attributes.Add(_traceIdAttribute);
+            Attributes.Add(_spanIdAttribute);
+            
             IncludeEventProperties = true;
             IncludeScopeProperties = true;
             SuppressSpaces = true;

--- a/src/NLog.Targets.Seq/Layouts/FormattedMessageLayout.cs
+++ b/src/NLog.Targets.Seq/Layouts/FormattedMessageLayout.cs
@@ -1,0 +1,53 @@
+﻿// Seq Target for NLog - Copyright 2014-2017 Datalust and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+using NLog.Config;
+using NLog.Layouts;
+
+namespace NLog.Targets.Seq.Layouts
+{
+    [ThreadAgnostic]
+    class FormattedMessageLayout : Layout
+    {
+        protected override void RenderFormattedMessage(LogEventInfo logEvent, StringBuilder target)
+        {
+            target.Append(GetFormattedMessage(logEvent));
+        }
+
+        protected override string GetFormattedMessage(LogEventInfo logEvent)
+        {
+            if (HasMessageTemplateSyntax(logEvent))
+            {
+                return string.Empty;    // Message Template Syntax, no need to include formatted message
+            }
+
+            return logEvent.FormattedMessage;
+        }
+
+        bool HasMessageTemplateSyntax(LogEventInfo logEvent)
+        {
+            if (!logEvent.HasProperties)
+                return false;
+
+            if (logEvent.Message?.IndexOf("{0", System.StringComparison.Ordinal) >= 0)
+            {
+                var mtp = logEvent.MessageTemplateParameters;
+                return !mtp.IsPositional;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/NLog.Targets.Seq/Layouts/RenderingsLayout.cs
+++ b/src/NLog.Targets.Seq/Layouts/RenderingsLayout.cs
@@ -18,7 +18,7 @@ using NLog.Config;
 using NLog.Layouts;
 using NLog.MessageTemplates;
 
-namespace NLog.Targets.Seq
+namespace NLog.Targets.Seq.Layouts
 {
     [ThreadAgnostic]
     class RenderingsLayout : Layout

--- a/src/NLog.Targets.Seq/NLog.Targets.Seq.csproj
+++ b/src/NLog.Targets.Seq/NLog.Targets.Seq.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>An NLog target that writes structured log events to Seq</Description>
     <Authors>Datalust;Contributors</Authors>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <VersionPrefix>3.1.1</VersionPrefix>
     <TargetFrameworks>net45;net462;netstandard2.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/NLog.Targets.Seq/NLog.Targets.Seq.csproj
+++ b/src/NLog.Targets.Seq/NLog.Targets.Seq.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>An NLog target that writes structured log events to Seq</Description>
     <Authors>Datalust;Contributors</Authors>
-    <VersionPrefix>3.1.1</VersionPrefix>
+    <VersionPrefix>3.2.0</VersionPrefix>
     <TargetFrameworks>net45;net462;netstandard2.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/NLog.Targets.Seq/NLog.Targets.Seq.csproj
+++ b/src/NLog.Targets.Seq/NLog.Targets.Seq.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <Description>An NLog target that writes structured log events to Seq</Description>
     <Authors>Datalust;Contributors</Authors>
-    <VersionPrefix>3.2.0</VersionPrefix>
-    <TargetFrameworks>net45;net462;netstandard2.0;net6.0</TargetFrameworks>
+    <VersionPrefix>4.0.0</VersionPrefix>
+    <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../asset/nlog-targets-seq.snk</AssemblyOriginatorKeyFile>

--- a/src/NLog.Targets.Seq/NLog.Targets.Seq.csproj
+++ b/src/NLog.Targets.Seq/NLog.Targets.Seq.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <Description>An NLog target that writes structured log events to Seq</Description>
     <Authors>Datalust;Contributors</Authors>
-    <VersionPrefix>3.2.0</VersionPrefix>
-    <TargetFrameworks>net45;net462;netstandard2.0;net6.0</TargetFrameworks>
+    <VersionPrefix>4.0.0</VersionPrefix>
+    <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../asset/nlog-targets-seq.snk</AssemblyOriginatorKeyFile>
@@ -17,7 +17,7 @@
     <RepositoryUrl>https://github.com/datalust/nlog-targets-seq.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -34,9 +34,10 @@
     <PackageReference Include="NLog" Version="5.2.5" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net462' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/NLog.Targets.Seq/NLog.Targets.Seq.csproj
+++ b/src/NLog.Targets.Seq/NLog.Targets.Seq.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <Description>An NLog target that writes structured log events to Seq</Description>
     <Authors>Datalust;Contributors</Authors>
-    <VersionPrefix>4.0.0</VersionPrefix>
-    <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+    <VersionPrefix>3.2.0</VersionPrefix>
+    <TargetFrameworks>net45;net462;netstandard2.0;net6.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../asset/nlog-targets-seq.snk</AssemblyOriginatorKeyFile>

--- a/src/NLog.Targets.Seq/SeqTarget.cs
+++ b/src/NLog.Targets.Seq/SeqTarget.cs
@@ -21,6 +21,8 @@ using System.Threading.Tasks;
 using NLog.Common;
 using NLog.Config;
 using NLog.Layouts;
+using NLog.Targets.Seq.Layouts;
+
 // ReSharper disable UnusedAutoPropertyAccessor.Global
 // ReSharper disable UnusedMember.Global
 // ReSharper disable MemberCanBePrivate.Global


### PR DESCRIPTION
 * #74 - **breaking** - drop .NET 4.5 support, collect `@TraceId` and `@SpanId` when present (@nblumhardt)
 * #75 - support mapping NLog levels to user-specified Seq levels (@snakefoot)
 * #76 - support additional HTTP header `<header name="" value="" />` configuration items (@nblumhardt)